### PR TITLE
Fix LearningDashboard props and store imports

### DIFF
--- a/src/components/LearningDashboard/LearningDashboard.tsx
+++ b/src/components/LearningDashboard/LearningDashboard.tsx
@@ -11,7 +11,7 @@ interface LearningDashboardProps {
   stackId: string;
 }
 
-export const LearningDashboard: React.FC<LearningDashboardProps> = ({ cards }) => {
+export const LearningDashboard: React.FC<LearningDashboardProps> = ({ cards, stackId }) => {
   // Zählt die Karten für jedes Level
   const navigate = useNavigate();
   const levelCounts = cards.reduce(

--- a/src/store/stackStore.ts
+++ b/src/store/stackStore.ts
@@ -1,7 +1,7 @@
 // src/store/stackStore.ts
 
 import { create } from 'zustand';
-import type { Stack } from '../types/stack.types';
+import type { Stack, StackSettings, VocabularyCard } from '../types/stack.types';
 
 // --- Mock-Daten (Test-Daten) ---
 // Wir initialisieren den Store mit unseren bekannten Test-Daten.


### PR DESCRIPTION
## Summary
- pass stackId prop to LearningDashboard
- import missing types in stackStore

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874281134dc832599b484b0632590b3